### PR TITLE
feat: 4626 get underlying

### DIFF
--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/interfaces/IERC4626.sol';
+import '../../interfaces/ITransformer.sol';
+
+/// @title An implementaton of `ITransformer` for tokens that implement `ERC4626`
+contract ERC4626Transformer is ITransformer {
+  /// @inheritdoc ITransformer
+  function getUnderlying(address _dependent) external view returns (address[] memory) {
+    return _toUnderlying(IERC4626(_dependent).asset());
+  }
+
+  /// @inheritdoc ITransformer
+  function calculateTransformToUnderlying(address _dependent, uint256 _amountDependent) external view returns (UnderlyingAmount[] memory) {}
+
+  /// @inheritdoc ITransformer
+  function calculateTransformToDependent(address _dependent, UnderlyingAmount[] calldata _underlying)
+    external
+    view
+    returns (uint256 _amountDependent)
+  {}
+
+  /// @inheritdoc ITransformer
+  function transformToUnderlying(
+    address _dependent,
+    uint256 _amountDependent,
+    address _recipient
+  ) external returns (UnderlyingAmount[] memory) {}
+
+  /// @inheritdoc ITransformer
+  function transformToDependent(
+    address _dependent,
+    UnderlyingAmount[] calldata _underlying,
+    address _recipient
+  ) external returns (uint256 _amountDependent) {}
+
+  function _toUnderlying(address _underlying) internal pure returns (address[] memory _underlyingArray) {
+    _underlyingArray = new address[](1);
+    _underlyingArray[0] = _underlying;
+  }
+}

--- a/test/unit/transformers/erc-4626-transformer.spec.ts
+++ b/test/unit/transformers/erc-4626-transformer.spec.ts
@@ -1,0 +1,39 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { then, when } from '@utils/bdd';
+import { ERC4626Transformer, ERC4626Transformer__factory, IERC4626 } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { smock, FakeContract } from '@defi-wonderland/smock';
+
+chai.use(smock.matchers);
+
+describe('ERC4626Transformer', () => {
+  const UNDERLYING = '0x0000000000000000000000000000000000000001';
+
+  let transformer: ERC4626Transformer;
+  let vault: FakeContract<IERC4626>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    vault = await smock.fake('IERC4626');
+    vault.asset.returns(UNDERLYING);
+    const adapterFactory: ERC4626Transformer__factory = await ethers.getContractFactory(
+      'solidity/contracts/transformers/ERC4626Transformer.sol:ERC4626Transformer'
+    );
+    transformer = await adapterFactory.deploy();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('getUnderlying', () => {
+    when('function is called', () => {
+      then('underlying token is returned correctly', async () => {
+        const underlying = await transformer.getUnderlying(vault.address);
+        expect(underlying).to.eql([UNDERLYING]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We are now adding `ERC4626Transformer`. For now, we only implemented `getUnderlying`