### PR TITLE
refactor: remove payable

### DIFF
--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -36,7 +36,7 @@ contract ERC4626Transformer is ITransformer {
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
-    address payable _recipient
+    address _recipient
   ) external returns (UnderlyingAmount[] memory) {
     address _underlying = IERC4626(_dependent).asset();
     uint256 _amount = IERC4626(_dependent).redeem(_amountDependent, _recipient, msg.sender);

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -35,11 +35,11 @@ contract ProtocolTokenWrapperTransformer is ITransformer {
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
-    address payable _recipient
+    address _recipient
   ) external returns (UnderlyingAmount[] memory) {
     IERC20(_dependent).safeTransferFrom(msg.sender, address(this), _amountDependent);
     IWETH9(_dependent).withdraw(_amountDependent);
-    _recipient.transfer(_amountDependent);
+    payable(_recipient).transfer(_amountDependent);
     return _toUnderylingAmount(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE, _amountDependent);
   }
 

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -54,7 +54,7 @@ interface ITransformer {
   function transformToUnderlying(
     address dependent,
     uint256 amountDependent,
-    address payable recipient
+    address recipient
   ) external returns (UnderlyingAmount[] memory);
 
   /**


### PR DESCRIPTION
We realized that there was only one transformer that required the recipient to be payable (the WETH/ETH one). So the idea is to remove it from the interface and just cast it in the necessary transformer