### PR TITLE
feat: registry add get underlying

### DIFF
--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -43,7 +43,8 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
 
   /// @inheritdoc ITransformer
   function getUnderlying(address _dependent) external view returns (address[] memory) {
-    // TODO: Implement
+    ITransformer _transformer = _getTransformerOrFail(_dependent);
+    return _transformer.getUnderlying(_dependent);
   }
 
   /// @inheritdoc ITransformer
@@ -76,5 +77,10 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _recipient
   ) external payable returns (uint256 _amountDependent) {
     // TODO: Implement
+  }
+
+  function _getTransformerOrFail(address _dependent) internal view returns (ITransformer _transformer) {
+    _transformer = _registeredTransformer[_dependent];
+    if (address(_transformer) == address(0)) revert NoTransformerRegistered(_dependent);
   }
 }

--- a/solidity/contracts/test/ITransformerERC165.sol
+++ b/solidity/contracts/test/ITransformerERC165.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
+import '../../interfaces/ITransformer.sol';
+
+// Note: necessary for smocking purposes
+interface ITransformerERC165 is IERC165, ITransformer {
+
+}

--- a/solidity/interfaces/ITransformerRegistry.sol
+++ b/solidity/interfaces/ITransformerRegistry.sol
@@ -23,6 +23,13 @@ interface ITransformerRegistry is ITransformer {
   error AddressIsNotTransformer(address account);
 
   /**
+   * @notice Thrown when trying to execute an action with a dependent that has no transformer
+   *          associated
+   * @param dependent The dependent that didn't have a transformer
+   */
+  error NoTransformerRegistered(address dependent);
+
+  /**
    * @notice Emitted when new dependents are registered
    * @param registrations The dependents that were registered
    */


### PR DESCRIPTION
We are now implementing `getUnderlying` at the registry level