### PR TITLE
refactor: add payable

### DIFF
--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -88,7 +88,7 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     uint256 _amountDependent,
     address _recipient
-  ) external returns (UnderlyingAmount[] memory) {
+  ) external payable returns (UnderlyingAmount[] memory) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
@@ -112,7 +112,7 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   }
 
   /// @inheritdoc ITransformerRegistry
-  function transformAllToUnderlying(address _dependent, address _recipient) external returns (UnderlyingAmount[] memory) {
+  function transformAllToUnderlying(address _dependent, address _recipient) external payable returns (UnderlyingAmount[] memory) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     uint256 _amountDependent = IERC20(_dependent).balanceOf(msg.sender);
     bytes memory _result = _delegateToTransformer(
@@ -123,7 +123,7 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   }
 
   /// @inheritdoc ITransformerRegistry
-  function transformAllToDependent(address _dependent, address _recipient) external returns (uint256) {
+  function transformAllToDependent(address _dependent, address _recipient) external payable returns (uint256) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
 
     // Calculate underlying
@@ -147,7 +147,7 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
-  ) external returns (uint256 _spentDependent) {
+  ) external payable returns (uint256 _spentDependent) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,

--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -59,7 +59,7 @@ contract ERC4626Transformer is BaseTransformer {
     address _dependent,
     uint256 _amountDependent,
     address _recipient
-  ) external returns (UnderlyingAmount[] memory) {
+  ) external payable returns (UnderlyingAmount[] memory) {
     address _underlying = IERC4626(_dependent).asset();
     uint256 _amount = IERC4626(_dependent).redeem(_amountDependent, _recipient, msg.sender);
     return _toUnderylingAmount(_underlying, _amount);
@@ -84,7 +84,7 @@ contract ERC4626Transformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
-  ) external returns (uint256 _spentDependent) {
+  ) external payable returns (uint256 _spentDependent) {
     _spentDependent = IERC4626(_dependent).withdraw(_expectedUnderlying[0].amount, _recipient, msg.sender);
   }
 

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -51,7 +51,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _dependent,
     uint256 _amountDependent,
     address _recipient
-  ) external returns (UnderlyingAmount[] memory) {
+  ) external payable returns (UnderlyingAmount[] memory) {
     _takeFromSenderAndUnwrap(IWETH9(_dependent), _amountDependent, _recipient);
     return _toUnderylingAmount(PROTOCOL_TOKEN, _amountDependent);
   }
@@ -71,7 +71,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
-  ) external returns (uint256 _spentDependent) {
+  ) external payable returns (uint256 _spentDependent) {
     _spentDependent = _expectedUnderlying[0].amount;
     _takeFromSenderAndUnwrap(IWETH9(_dependent), _spentDependent, _recipient);
   }

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -10,6 +10,7 @@ pragma solidity >=0.5.0;
  *           - LP tokens
  *         Now, transformers are smart contract that knows how to map dependent tokens into their underlying counterparts,
  *         and vice-versa. We are doing this so that we can abstract the way tokens can be transformed between each other
+ * @dev All non-view functions were made payable, so that they could be multicalled when msg.value > 0
  */
 interface ITransformer {
   /// @notice An amount of an underlying token
@@ -89,7 +90,7 @@ interface ITransformer {
     address dependent,
     uint256 amountDependent,
     address recipient
-  ) external returns (UnderlyingAmount[] memory);
+  ) external payable returns (UnderlyingAmount[] memory);
 
   /**
    * @notice Executes the transformation to the dependent token
@@ -115,7 +116,7 @@ interface ITransformer {
     address dependent,
     UnderlyingAmount[] calldata expectedUnderlying,
     address recipient
-  ) external returns (uint256 spentDependent);
+  ) external payable returns (uint256 spentDependent);
 
   /**
    * @notice Transforms underlying tokens to an expected amount of dependent tokens

--- a/solidity/interfaces/ITransformerRegistry.sol
+++ b/solidity/interfaces/ITransformerRegistry.sol
@@ -65,19 +65,21 @@ interface ITransformerRegistry is ITransformer {
   /**
    * @notice Executes a transformation to the underlying tokens, by taking the caller's entire
    *         dependent balance. This is meant to be used as part of a multi-hop swap
+   * @dev This function was made payable, so that it could be multicalled when msg.value > 0
    * @param dependent The address of the dependent token
    * @param recipient The address that would receive the underlying tokens
    * @return The transformed amount in each of the underlying tokens
    */
-  function transformAllToUnderlying(address dependent, address recipient) external returns (UnderlyingAmount[] memory);
+  function transformAllToUnderlying(address dependent, address recipient) external payable returns (UnderlyingAmount[] memory);
 
   /**
    * @notice Executes a transformation to the dependent token, by taking the caller's entire
    *         underlying balance. This is meant to be used as part of a multi-hop swap
    * @dev This function will not work when the underlying token is ETH/MATIC/BNB, since it can't be taken from the caller
+   *      This function was made payable, so that it could be multicalled when msg.value > 0
    * @param dependent The address of the dependent token
    * @param recipient The address that would receive the dependent tokens
    * @return amountDependent The transformed amount in the dependent token
    */
-  function transformAllToDependent(address dependent, address recipient) external returns (uint256 amountDependent);
+  function transformAllToDependent(address dependent, address recipient) external payable returns (uint256 amountDependent);
 }


### PR DESCRIPTION
We are now making some functions payable, even though they don't technically need it. We are doing this because we would want all transformation functions to be multicall-able. But we can't multicall payable and non-payable functions together, so we will make all of them payable