### PR TITLE
refactor: use send value

### DIFF
--- a/deploy/001_ERC_4626_transformer.ts
+++ b/deploy/001_ERC_4626_transformer.ts
@@ -4,7 +4,7 @@ import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-f
 import { DeployFunction } from '@0xged/hardhat-deploy/dist/types';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer, admin } = await hre.getNamedAccounts();
+  const { deployer, governor } = await hre.getNamedAccounts();
 
   await deployThroughDeterministicFactory({
     deployer,
@@ -14,7 +14,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     bytecode: ERC4626Transformer__factory.bytecode,
     constructorArgs: {
       types: ['address'],
-      values: [admin],
+      values: [governor],
     },
     log: !process.env.TEST,
     overrides: {

--- a/deploy/002_protocol_token_transformer.ts
+++ b/deploy/002_protocol_token_transformer.ts
@@ -4,7 +4,7 @@ import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-f
 import { DeployFunction } from '@0xged/hardhat-deploy/dist/types';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer, admin } = await hre.getNamedAccounts();
+  const { deployer, governor } = await hre.getNamedAccounts();
 
   await deployThroughDeterministicFactory({
     deployer,
@@ -14,7 +14,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     bytecode: ProtocolTokenWrapperTransformer__factory.bytecode,
     constructorArgs: {
       types: ['address'],
-      values: [admin],
+      values: [governor],
     },
     log: !process.env.TEST,
     overrides: {

--- a/deploy/003_transformer_registry.ts
+++ b/deploy/003_transformer_registry.ts
@@ -4,7 +4,7 @@ import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-f
 import { DeployFunction } from '@0xged/hardhat-deploy/dist/types';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployer, admin } = await hre.getNamedAccounts();
+  const { deployer, governor } = await hre.getNamedAccounts();
 
   await deployThroughDeterministicFactory({
     deployer,
@@ -14,7 +14,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     bytecode: TransformerRegistry__factory.bytecode,
     constructorArgs: {
       types: ['address'],
-      values: [admin],
+      values: [governor],
     },
     log: !process.env.TEST,
     overrides: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -75,7 +75,7 @@ const config: HardhatUserConfig = {
     deployer: {
       default: 0,
     },
-    admin: {
+    governor: {
       optimism: '0x308810881807189cAe91950888b2cB73A1CC5920',
       polygon: '0xCe9F6991b48970d6c9Ef99Fffb112359584488e3',
       arbitrum: '0x84F4836e8022765Af9FBCE3Bb2887fD826c668f1',

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -4,12 +4,14 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/interfaces/IERC20.sol';
+import '@openzeppelin/contracts/utils/Address.sol';
 import './BaseTransformer.sol';
 
 /// @title An implementaton of `ITransformer` for protocol token wrappers (WETH/WBNB/WMATIC)
 contract ProtocolTokenWrapperTransformer is BaseTransformer {
   using SafeERC20 for IERC20;
   using SafeERC20 for IWETH9;
+  using Address for address payable;
 
   constructor(address _governor) Governable(_governor) {}
 
@@ -96,7 +98,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   ) internal {
     _dependent.safeTransferFrom(msg.sender, address(this), _amount);
     _dependent.withdraw(_amount);
-    payable(_recipient).transfer(_amount);
+    payable(_recipient).sendValue(_amount);
   }
 
   // slither-disable-next-line arbitrary-send

--- a/solidity/contracts/utils/CollectableDust.sol
+++ b/solidity/contracts/utils/CollectableDust.sol
@@ -4,11 +4,13 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/interfaces/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import '@openzeppelin/contracts/utils/Address.sol';
 import '../../interfaces/utils/ICollectableDust.sol';
 import './Governable.sol';
 
 abstract contract CollectableDust is Governable, ICollectableDust {
   using SafeERC20 for IERC20;
+  using Address for address payable;
 
   /// @inheritdoc ICollectableDust
   address public constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
@@ -30,7 +32,7 @@ abstract contract CollectableDust is Governable, ICollectableDust {
   ) external onlyGovernor {
     if (_recipient == address(0)) revert DustRecipientIsZeroAddress();
     if (_token == PROTOCOL_TOKEN) {
-      payable(_recipient).transfer(_amount);
+      payable(_recipient).sendValue(_amount);
     } else {
       IERC20(_token).safeTransfer(_recipient, _amount);
     }


### PR DESCRIPTION
We are now using OZ's `sendValue` instead of transfer, so that we can send ETH/MATIC/BNB to contracts with an expensive receive/fallback function