### PR TITLE
refactor: erc4626 fail with invalid underlying input

### DIFF
--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -31,6 +31,7 @@ contract ERC4626Transformer is BaseTransformer {
     view
     returns (uint256 _amountDependent)
   {
+    if (_underlying.length != 1) revert InvalidUnderlyingInput();
     _amountDependent = IERC4626(_dependent).previewDeposit(_underlying[0].amount);
   }
 
@@ -40,6 +41,7 @@ contract ERC4626Transformer is BaseTransformer {
     view
     returns (uint256 _neededDependent)
   {
+    if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _neededDependent = IERC4626(_dependent).previewWithdraw(_expectedUnderlying[0].amount);
   }
 
@@ -71,6 +73,7 @@ contract ERC4626Transformer is BaseTransformer {
     UnderlyingAmount[] calldata _underlying,
     address _recipient
   ) external payable returns (uint256 _amountDependent) {
+    if (_underlying.length != 1) revert InvalidUnderlyingInput();
     IERC20 _underlyingToken = IERC20(_underlying[0].underlying);
     uint256 _underlyingAmount = _underlying[0].amount;
     // We need to take the tokens from the sender, and approve them so that the vault can take it from us
@@ -85,6 +88,7 @@ contract ERC4626Transformer is BaseTransformer {
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
   ) external payable returns (uint256 _spentDependent) {
+    if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _spentDependent = IERC4626(_dependent).withdraw(_expectedUnderlying[0].amount, _recipient, msg.sender);
   }
 

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -19,6 +19,9 @@ interface ITransformer {
     uint256 amount;
   }
 
+  /// @notice Thrown when the underlying input is not valid for the used transformer
+  error InvalidUnderlyingInput();
+
   /**
    * @notice Returns the addresses of all the underlying tokens, for the given dependent
    * @dev This function must be unaware of context. The returned values must be the same,

--- a/test/unit/transformers/erc-4626-transformer.spec.ts
+++ b/test/unit/transformers/erc-4626-transformer.spec.ts
@@ -190,7 +190,7 @@ describe('ERC4626Transformer', () => {
 
   describe('transformToExpectedUnderlying', () => {
     invalidUnderlyingInputTest({
-      func: 'transformToDependent',
+      func: 'transformToExpectedUnderlying',
       input: (underlying) => [vault.address, underlying, recipient.address],
     });
     when('function is called', () => {


### PR DESCRIPTION
We are now failing when the underlying input is invalid (`underlying.length != 1`)