### PR TITLE
refactor: native fail with invalid underlying input

### DIFF
--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -31,6 +31,7 @@ contract ERC4626Transformer is BaseTransformer {
     view
     returns (uint256 _amountDependent)
   {
+    if (_underlying.length != 1) revert InvalidUnderlyingInput();
     _amountDependent = IERC4626(_dependent).previewDeposit(_underlying[0].amount);
   }
 
@@ -40,6 +41,7 @@ contract ERC4626Transformer is BaseTransformer {
     view
     returns (uint256 _neededDependent)
   {
+    if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _neededDependent = IERC4626(_dependent).previewWithdraw(_expectedUnderlying[0].amount);
   }
 
@@ -71,6 +73,7 @@ contract ERC4626Transformer is BaseTransformer {
     UnderlyingAmount[] calldata _underlying,
     address _recipient
   ) external payable returns (uint256 _amountDependent) {
+    if (_underlying.length != 1) revert InvalidUnderlyingInput();
     IERC20 _underlyingToken = IERC20(_underlying[0].underlying);
     uint256 _underlyingAmount = _underlying[0].amount;
     // We need to take the tokens from the sender, and approve them so that the vault can take it from us
@@ -85,6 +88,7 @@ contract ERC4626Transformer is BaseTransformer {
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
   ) external payable returns (uint256 _spentDependent) {
+    if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _spentDependent = IERC4626(_dependent).withdraw(_expectedUnderlying[0].amount, _recipient, msg.sender);
   }
 

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -27,6 +27,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
 
   /// @inheritdoc ITransformer
   function calculateTransformToDependent(address, UnderlyingAmount[] calldata _underlying) external pure returns (uint256 _amountDependent) {
+    if (_underlying.length != 1) revert InvalidUnderlyingInput();
     _amountDependent = _underlying[0].amount;
   }
 
@@ -36,6 +37,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     pure
     returns (uint256 _neededDependent)
   {
+    if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _neededDependent = _expectedUnderlying[0].amount;
   }
 
@@ -64,6 +66,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     UnderlyingAmount[] calldata _underlying,
     address _recipient
   ) external payable returns (uint256 _amountDependent) {
+    if (_underlying.length != 1) revert InvalidUnderlyingInput();
     _amountDependent = _underlying[0].amount;
     _wrapAndTransfer(IWETH9(_dependent), _amountDependent, _recipient);
   }
@@ -74,6 +77,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient
   ) external payable returns (uint256 _spentDependent) {
+    if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _spentDependent = _expectedUnderlying[0].amount;
     _takeFromSenderAndUnwrap(IWETH9(_dependent), _spentDependent, _recipient);
   }

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -19,6 +19,9 @@ interface ITransformer {
     uint256 amount;
   }
 
+  /// @notice Thrown when the underlying input is not valid for the used transformer
+  error InvalidUnderlyingInput();
+
   /**
    * @notice Returns the addresses of all the underlying tokens, for the given dependent
    * @dev This function must be unaware of context. The returned values must be the same,

--- a/test/unit/transformers/erc-4626-transformer.spec.ts
+++ b/test/unit/transformers/erc-4626-transformer.spec.ts
@@ -190,7 +190,7 @@ describe('ERC4626Transformer', () => {
 
   describe('transformToExpectedUnderlying', () => {
     invalidUnderlyingInputTest({
-      func: 'transformToDependent',
+      func: 'transformToExpectedUnderlying',
       input: (underlying) => [vault.address, underlying, recipient.address],
     });
     when('function is called', () => {

--- a/test/unit/transformers/protocol-token-wrapper-transformer.spec.ts
+++ b/test/unit/transformers/protocol-token-wrapper-transformer.spec.ts
@@ -96,7 +96,7 @@ describe('ProtocolTokenWrapperTransformer', () => {
 
   describe('calculateNeededToTransformToUnderlying', () => {
     invalidUnderlyingInputTest({
-      func: 'calculateTransformToDependent',
+      func: 'calculateNeededToTransformToUnderlying',
       input: (underlying) => [wToken.address, underlying],
     });
     when('function is called', () => {
@@ -160,7 +160,7 @@ describe('ProtocolTokenWrapperTransformer', () => {
 
   describe('transformToDependent', () => {
     invalidUnderlyingInputTest({
-      func: 'calculateTransformToDependent',
+      func: 'transformToDependent',
       input: (underlying) => [wToken.address, underlying],
     });
     when('sending less in value than specified as parameter', () => {
@@ -208,7 +208,7 @@ describe('ProtocolTokenWrapperTransformer', () => {
 
   describe('transformToExpectedUnderlying', () => {
     invalidUnderlyingInputTest({
-      func: 'calculateTransformToDependent',
+      func: 'transformToExpectedUnderlying',
       input: (underlying) => [wToken.address, underlying],
     });
     when('function is called', () => {

--- a/test/unit/transformers/protocol-token-wrapper-transformer.spec.ts
+++ b/test/unit/transformers/protocol-token-wrapper-transformer.spec.ts
@@ -161,7 +161,7 @@ describe('ProtocolTokenWrapperTransformer', () => {
   describe('transformToDependent', () => {
     invalidUnderlyingInputTest({
       func: 'transformToDependent',
-      input: (underlying) => [wToken.address, underlying],
+      input: (underlying) => [wToken.address, underlying, RECIPIENT],
     });
     when('sending less in value than specified as parameter', () => {
       let tx: Promise<TransactionResponse>;
@@ -209,7 +209,7 @@ describe('ProtocolTokenWrapperTransformer', () => {
   describe('transformToExpectedUnderlying', () => {
     invalidUnderlyingInputTest({
       func: 'transformToExpectedUnderlying',
-      input: (underlying) => [wToken.address, underlying],
+      input: (underlying) => [wToken.address, underlying, RECIPIENT],
     });
     when('function is called', () => {
       given(async () => {


### PR DESCRIPTION
Same as #42, but with `ProtocolTokenWrapperTransformer`