### PR TITLE
refactor: use unchecked and rename internal functions

### DIFF
--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -15,14 +15,14 @@ contract ERC4626Transformer is BaseTransformer {
 
   /// @inheritdoc ITransformer
   function getUnderlying(address _dependent) external view returns (address[] memory) {
-    return _toUnderlying(IERC4626(_dependent).asset());
+    return _toSingletonArray(IERC4626(_dependent).asset());
   }
 
   /// @inheritdoc ITransformer
   function calculateTransformToUnderlying(address _dependent, uint256 _amountDependent) external view returns (UnderlyingAmount[] memory) {
     address _underlying = IERC4626(_dependent).asset();
     uint256 _amount = IERC4626(_dependent).previewRedeem(_amountDependent);
-    return _toUnderylingAmount(_underlying, _amount);
+    return _toSingletonArray(_underlying, _amount);
   }
 
   /// @inheritdoc ITransformer
@@ -51,7 +51,7 @@ contract ERC4626Transformer is BaseTransformer {
   {
     address _underlying = IERC4626(_dependent).asset();
     uint256 _amount = IERC4626(_dependent).previewMint(_expectedDependent);
-    return _toUnderylingAmount(_underlying, _amount);
+    return _toSingletonArray(_underlying, _amount);
   }
 
   /// @inheritdoc ITransformer
@@ -62,7 +62,7 @@ contract ERC4626Transformer is BaseTransformer {
   ) external payable returns (UnderlyingAmount[] memory) {
     address _underlying = IERC4626(_dependent).asset();
     uint256 _amount = IERC4626(_dependent).redeem(_amountDependent, _recipient, msg.sender);
-    return _toUnderylingAmount(_underlying, _amount);
+    return _toSingletonArray(_underlying, _amount);
   }
 
   /// @inheritdoc ITransformer
@@ -104,17 +104,19 @@ contract ERC4626Transformer is BaseTransformer {
     uint256 _spentUnderlying = IERC4626(_dependent).mint(_expectedDependent, _recipient);
     // If some tokens were left unspent, then return to caller
     if (_spentUnderlying < _neededUnderlying) {
-      _underlying.safeTransfer(msg.sender, _neededUnderlying - _spentUnderlying);
+      unchecked {
+        _underlying.safeTransfer(msg.sender, _neededUnderlying - _spentUnderlying);
+      }
     }
-    return _toUnderylingAmount(address(_underlying), _spentUnderlying);
+    return _toSingletonArray(address(_underlying), _spentUnderlying);
   }
 
-  function _toUnderlying(address _underlying) internal pure returns (address[] memory _underlyingArray) {
+  function _toSingletonArray(address _underlying) internal pure returns (address[] memory _underlyingArray) {
     _underlyingArray = new address[](1);
     _underlyingArray[0] = _underlying;
   }
 
-  function _toUnderylingAmount(address _underlying, uint256 _amount) internal pure returns (UnderlyingAmount[] memory _amounts) {
+  function _toSingletonArray(address _underlying, uint256 _amount) internal pure returns (UnderlyingAmount[] memory _amounts) {
     _amounts = new UnderlyingAmount[](1);
     _amounts[0] = UnderlyingAmount({underlying: _underlying, amount: _amount});
   }

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -17,12 +17,12 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
 
   /// @inheritdoc ITransformer
   function getUnderlying(address) external pure returns (address[] memory) {
-    return _toUnderlying(PROTOCOL_TOKEN);
+    return _toSingletonArray(PROTOCOL_TOKEN);
   }
 
   /// @inheritdoc ITransformer
   function calculateTransformToUnderlying(address, uint256 _amountDependent) external pure returns (UnderlyingAmount[] memory) {
-    return _toUnderylingAmount(PROTOCOL_TOKEN, _amountDependent);
+    return _toSingletonArray(PROTOCOL_TOKEN, _amountDependent);
   }
 
   /// @inheritdoc ITransformer
@@ -45,7 +45,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     pure
     returns (UnderlyingAmount[] memory _neededUnderlying)
   {
-    return _toUnderylingAmount(PROTOCOL_TOKEN, _expectedDependent);
+    return _toSingletonArray(PROTOCOL_TOKEN, _expectedDependent);
   }
 
   /// @inheritdoc ITransformer
@@ -55,7 +55,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _recipient
   ) external payable returns (UnderlyingAmount[] memory) {
     _takeFromSenderAndUnwrap(IWETH9(_dependent), _amountDependent, _recipient);
-    return _toUnderylingAmount(PROTOCOL_TOKEN, _amountDependent);
+    return _toSingletonArray(PROTOCOL_TOKEN, _amountDependent);
   }
 
   /// @inheritdoc ITransformer
@@ -85,7 +85,7 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _recipient
   ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {
     _wrapAndTransfer(IWETH9(_dependent), _expectedDependent, _recipient);
-    return _toUnderylingAmount(PROTOCOL_TOKEN, _expectedDependent);
+    return _toSingletonArray(PROTOCOL_TOKEN, _expectedDependent);
   }
 
   receive() external payable {}
@@ -111,12 +111,12 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     _dependent.safeTransfer(_recipient, _amount);
   }
 
-  function _toUnderlying(address _underlying) internal pure returns (address[] memory _underlyingArray) {
+  function _toSingletonArray(address _underlying) internal pure returns (address[] memory _underlyingArray) {
     _underlyingArray = new address[](1);
     _underlyingArray[0] = _underlying;
   }
 
-  function _toUnderylingAmount(address _underlying, uint256 _amount) internal pure returns (UnderlyingAmount[] memory _amounts) {
+  function _toSingletonArray(address _underlying, uint256 _amount) internal pure returns (UnderlyingAmount[] memory _amounts) {
     _amounts = new UnderlyingAmount[](1);
     _amounts[0] = UnderlyingAmount({underlying: _underlying, amount: _amount});
   }


### PR DESCRIPTION
We are renaming internal functions, and using `unchecked` when possible, for a little gas saving