### PR TITLE
feat: add mix man amounts

### DIFF
--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -87,12 +87,13 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
-    address _recipient
+    address _recipient,
+    UnderlyingAmount[] calldata _minAmountOut
   ) external payable returns (UnderlyingAmount[] memory) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient)
+      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient, _minAmountOut)
     );
     return abi.decode(_result, (UnderlyingAmount[]));
   }
@@ -101,29 +102,38 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   function transformToDependent(
     address _dependent,
     UnderlyingAmount[] calldata _underlying,
-    address _recipient
+    address _recipient,
+    uint256 _minAmountOut
   ) external payable returns (uint256 _amountDependent) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlying, _recipient)
+      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlying, _recipient, _minAmountOut)
     );
     return abi.decode(_result, (uint256));
   }
 
   /// @inheritdoc ITransformerRegistry
-  function transformAllToUnderlying(address _dependent, address _recipient) external payable returns (UnderlyingAmount[] memory) {
+  function transformAllToUnderlying(
+    address _dependent,
+    address _recipient,
+    UnderlyingAmount[] memory _minAmountOut
+  ) external payable returns (UnderlyingAmount[] memory) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     uint256 _amountDependent = IERC20(_dependent).balanceOf(msg.sender);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient)
+      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient, _minAmountOut)
     );
     return abi.decode(_result, (UnderlyingAmount[]));
   }
 
   /// @inheritdoc ITransformerRegistry
-  function transformAllToDependent(address _dependent, address _recipient) external payable returns (uint256) {
+  function transformAllToDependent(
+    address _dependent,
+    address _recipient,
+    uint256 _minAmountOut
+  ) external payable returns (uint256) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
 
     // Calculate underlying
@@ -138,7 +148,7 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     // Delegate
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlyingAmount, _recipient)
+      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlyingAmount, _recipient, _minAmountOut)
     );
     return abi.decode(_result, (uint256));
   }
@@ -147,12 +157,13 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   function transformToExpectedUnderlying(
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
-    address _recipient
+    address _recipient,
+    uint256 _maxAmountIn
   ) external payable returns (uint256 _spentDependent) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToExpectedUnderlying.selector, _dependent, _expectedUnderlying, _recipient)
+      abi.encodeWithSelector(_transformer.transformToExpectedUnderlying.selector, _dependent, _expectedUnderlying, _recipient, _maxAmountIn)
     );
     return abi.decode(_result, (uint256));
   }
@@ -161,12 +172,13 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   function transformToExpectedDependent(
     address _dependent,
     uint256 _expectedDependent,
-    address _recipient
+    address _recipient,
+    UnderlyingAmount[] calldata _maxAmountIn
   ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToExpectedDependent.selector, _dependent, _expectedDependent, _recipient)
+      abi.encodeWithSelector(_transformer.transformToExpectedDependent.selector, _dependent, _expectedDependent, _recipient, _maxAmountIn)
     );
     return abi.decode(_result, (UnderlyingAmount[]));
   }

--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -60,7 +60,8 @@ contract ERC4626Transformer is BaseTransformer {
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
-    address _recipient
+    address _recipient,
+    UnderlyingAmount[] calldata _minAmountOut
   ) external payable returns (UnderlyingAmount[] memory) {
     address _underlying = IERC4626(_dependent).asset();
     uint256 _amount = IERC4626(_dependent).redeem(_amountDependent, _recipient, msg.sender);
@@ -71,7 +72,8 @@ contract ERC4626Transformer is BaseTransformer {
   function transformToDependent(
     address _dependent,
     UnderlyingAmount[] calldata _underlying,
-    address _recipient
+    address _recipient,
+    uint256 _minAmountOut
   ) external payable returns (uint256 _amountDependent) {
     if (_underlying.length != 1) revert InvalidUnderlyingInput();
     IERC20 _underlyingToken = IERC20(_underlying[0].underlying);
@@ -86,7 +88,8 @@ contract ERC4626Transformer is BaseTransformer {
   function transformToExpectedUnderlying(
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
-    address _recipient
+    address _recipient,
+    uint256 _maxAmountIn
   ) external payable returns (uint256 _spentDependent) {
     if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _spentDependent = IERC4626(_dependent).withdraw(_expectedUnderlying[0].amount, _recipient, msg.sender);
@@ -96,7 +99,8 @@ contract ERC4626Transformer is BaseTransformer {
   function transformToExpectedDependent(
     address _dependent,
     uint256 _expectedDependent,
-    address _recipient
+    address _recipient,
+    UnderlyingAmount[] calldata _maxAmountIn
   ) external payable returns (UnderlyingAmount[] memory) {
     // Check how much underlying would be needed to mint the vault tokens
     uint256 _neededUnderlying = IERC4626(_dependent).previewMint(_expectedDependent);

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -54,7 +54,8 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   function transformToUnderlying(
     address _dependent,
     uint256 _amountDependent,
-    address _recipient
+    address _recipient,
+    UnderlyingAmount[] calldata _minAmountOut
   ) external payable returns (UnderlyingAmount[] memory) {
     _takeFromSenderAndUnwrap(IWETH9(_dependent), _amountDependent, _recipient);
     return _toSingletonArray(PROTOCOL_TOKEN, _amountDependent);
@@ -64,7 +65,8 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   function transformToDependent(
     address _dependent,
     UnderlyingAmount[] calldata _underlying,
-    address _recipient
+    address _recipient,
+    uint256 _minAmountOut
   ) external payable returns (uint256 _amountDependent) {
     if (_underlying.length != 1) revert InvalidUnderlyingInput();
     _amountDependent = _underlying[0].amount;
@@ -75,7 +77,8 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   function transformToExpectedUnderlying(
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
-    address _recipient
+    address _recipient,
+    uint256 _maxAmountIn
   ) external payable returns (uint256 _spentDependent) {
     if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _spentDependent = _expectedUnderlying[0].amount;
@@ -86,7 +89,8 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
   function transformToExpectedDependent(
     address _dependent,
     uint256 _expectedDependent,
-    address _recipient
+    address _recipient,
+    UnderlyingAmount[] calldata _maxAmountIn
   ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {
     _wrapAndTransfer(IWETH9(_dependent), _expectedDependent, _recipient);
     return _toSingletonArray(PROTOCOL_TOKEN, _expectedDependent);

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -87,12 +87,16 @@ interface ITransformer {
    * @param dependent The address of the dependent token
    * @param amountDependent The amount to transform
    * @param recipient The address that would receive the underlying tokens
+   * @param minAmountOut The minimum amount of underlying that the caller expects to get. Will fail
+   *                     if less is received. As a general rule, the underlying tokens should
+   *                     be provided in the same order as `getUnderlying` returns them
    * @return The transformed amount in each of the underlying tokens
    */
   function transformToUnderlying(
     address dependent,
     uint256 amountDependent,
-    address recipient
+    address recipient,
+    UnderlyingAmount[] calldata minAmountOut
   ) external payable returns (UnderlyingAmount[] memory);
 
   /**
@@ -100,12 +104,15 @@ interface ITransformer {
    * @param dependent The address of the dependent token
    * @param underlying The amounts of underlying tokens to transform
    * @param recipient The address that would receive the dependent tokens
+   * @param minAmountOut The minimum amount of dependent that the caller expects to get. Will fail
+   *                     if less is received
    * @return amountDependent The transformed amount in the dependent token
    */
   function transformToDependent(
     address dependent,
     UnderlyingAmount[] calldata underlying,
-    address recipient
+    address recipient,
+    uint256 minAmountOut
   ) external payable returns (uint256 amountDependent);
 
   /**
@@ -113,12 +120,15 @@ interface ITransformer {
    * @param dependent The address of the dependent token
    * @param expectedUnderlying The expected amounts of underlying tokens
    * @param recipient The address that would receive the underlying tokens
+   * @param maxAmountIn The maximum amount of dependent that the caller is willing to spend.
+   *                    Will fail more is needed
    * @return spentDependent The amount of spent dependent tokens
    */
   function transformToExpectedUnderlying(
     address dependent,
     UnderlyingAmount[] calldata expectedUnderlying,
-    address recipient
+    address recipient,
+    uint256 maxAmountIn
   ) external payable returns (uint256 spentDependent);
 
   /**
@@ -126,11 +136,15 @@ interface ITransformer {
    * @param dependent The address of the dependent token
    * @param expectedDependent The expected amounts of dependent tokens
    * @param recipient The address that would receive the underlying tokens
+   * @param maxAmountIn The maximum amount of underlying that the caller is willing to spend.
+   *                    Will fail more is needed. As a general rule, the underlying tokens should
+   *                    be provided in the same order as `getUnderlying` returns them
    * @return spentUnderlying The amount of spent underlying tokens
    */
   function transformToExpectedDependent(
     address dependent,
     uint256 expectedDependent,
-    address recipient
+    address recipient,
+    UnderlyingAmount[] calldata maxAmountIn
   ) external payable returns (UnderlyingAmount[] memory spentUnderlying);
 }

--- a/solidity/interfaces/ITransformerRegistry.sol
+++ b/solidity/interfaces/ITransformerRegistry.sol
@@ -68,9 +68,16 @@ interface ITransformerRegistry is ITransformer {
    * @dev This function was made payable, so that it could be multicalled when msg.value > 0
    * @param dependent The address of the dependent token
    * @param recipient The address that would receive the underlying tokens
+   * @param minAmountOut The minimum amount of underlying that the caller expects to get. Will fail
+   *                     if less is received. As a general rule, the underlying tokens should
+   *                     be provided in the same order as `getUnderlying` returns them
    * @return The transformed amount in each of the underlying tokens
    */
-  function transformAllToUnderlying(address dependent, address recipient) external payable returns (UnderlyingAmount[] memory);
+  function transformAllToUnderlying(
+    address dependent,
+    address recipient,
+    UnderlyingAmount[] calldata minAmountOut
+  ) external payable returns (UnderlyingAmount[] memory);
 
   /**
    * @notice Executes a transformation to the dependent token, by taking the caller's entire
@@ -79,7 +86,13 @@ interface ITransformerRegistry is ITransformer {
    *      This function was made payable, so that it could be multicalled when msg.value > 0
    * @param dependent The address of the dependent token
    * @param recipient The address that would receive the dependent tokens
+   * @param minAmountOut The minimum amount of dependent that the caller expects to get. Will fail
+   *                     if less is received
    * @return amountDependent The transformed amount in the dependent token
    */
-  function transformAllToDependent(address dependent, address recipient) external payable returns (uint256 amountDependent);
+  function transformAllToDependent(
+    address dependent,
+    address recipient,
+    uint256 minAmountOut
+  ) external payable returns (uint256 amountDependent);
 }

--- a/test/integration/comprehensive-transformer-test.spec.ts
+++ b/test/integration/comprehensive-transformer-test.spec.ts
@@ -239,7 +239,7 @@ describe('Comprehensive Transformer Test', () => {
           given(async () => {
             await dependent.connect(signer).approve(transformer.address, AMOUNT_DEPENDENT);
             expectedUnderlying = await transformer.calculateTransformToUnderlying(dependent.address, AMOUNT_DEPENDENT);
-            await transformer.connect(signer).transformToUnderlying(dependent.address, AMOUNT_DEPENDENT, RECIPIENT);
+            await transformer.connect(signer).transformToUnderlying(dependent.address, AMOUNT_DEPENDENT, RECIPIENT, expectedUnderlying);
           });
           then('allowance is spent', async () => {
             expect(await dependent.allowance(signer.address, transformer.address)).to.equal(0);
@@ -269,7 +269,7 @@ describe('Comprehensive Transformer Test', () => {
               await underlyingToken.connect(signer).approve(transformer.address, AMOUNT_PER_UNDERLYING);
             }
             expectedDependent = await transformer.calculateTransformToDependent(dependent.address, input);
-            const tx = await transformer.connect(signer).transformToDependent(dependent.address, input, RECIPIENT, { value });
+            const tx = await transformer.connect(signer).transformToDependent(dependent.address, input, RECIPIENT, expectedDependent, { value });
             const { gasUsed, effectiveGasPrice } = await tx.wait();
             gasSpent = gasUsed.mul(effectiveGasPrice);
           });
@@ -302,7 +302,7 @@ describe('Comprehensive Transformer Test', () => {
             const input = underlying.map((token) => ({ underlying: token.address, amount: AMOUNT_PER_UNDERLYING }));
             neededDependent = await transformer.calculateNeededToTransformToUnderlying(dependent.address, input);
             await dependent.connect(signer).approve(transformer.address, neededDependent);
-            await transformer.connect(signer).transformToExpectedUnderlying(dependent.address, input, RECIPIENT);
+            await transformer.connect(signer).transformToExpectedUnderlying(dependent.address, input, RECIPIENT, neededDependent);
           });
           then('allowance is spent', async () => {
             expect(await dependent.allowance(signer.address, transformer.address)).to.equal(0);
@@ -331,7 +331,9 @@ describe('Comprehensive Transformer Test', () => {
               await underlyingToken.connect(signer).approve(transformer.address, amount);
             }
             const value = isTokenUnderyling(PROTOCOL_TOKEN) ? neededUnderlying[0].amount : constants.Zero;
-            const tx = await transformer.connect(signer).transformToExpectedDependent(dependent.address, AMOUNT_DEPENDENT, RECIPIENT, { value });
+            const tx = await transformer
+              .connect(signer)
+              .transformToExpectedDependent(dependent.address, AMOUNT_DEPENDENT, RECIPIENT, neededUnderlying, { value });
             const { gasUsed, effectiveGasPrice } = await tx.wait();
             gasSpent = gasUsed.mul(effectiveGasPrice);
           });

--- a/test/integration/registry-transform-all.spec.ts
+++ b/test/integration/registry-transform-all.spec.ts
@@ -83,7 +83,7 @@ describe('Transformer Registry - Transform All', () => {
       given(async () => {
         await dependent.connect(signer).approve(registry.address, INITIAL_DEPENDENT_BALANCE);
         expectedUnderlying = await registry.calculateTransformToUnderlying(dependent.address, INITIAL_DEPENDENT_BALANCE);
-        await registry.connect(signer).transformAllToUnderlying(dependent.address, RECIPIENT);
+        await registry.connect(signer).transformAllToUnderlying(dependent.address, RECIPIENT, expectedUnderlying);
       });
       then('allowance is spent', async () => {
         expect(await dependent.allowance(signer.address, registry.address)).to.equal(0);
@@ -106,7 +106,7 @@ describe('Transformer Registry - Transform All', () => {
         expectedDependent = await registry.calculateTransformToDependent(dependent.address, [
           { underlying: underlying.address, amount: INITIAL_UNDERLYING_BALANCE },
         ]);
-        await registry.connect(signer).transformAllToDependent(dependent.address, RECIPIENT);
+        await registry.connect(signer).transformAllToDependent(dependent.address, RECIPIENT, expectedDependent);
       });
       then('allowance is spent for all underlying tokens', async () => {
         expect(await underlying.allowance(signer.address, registry.address)).to.equal(0);
@@ -125,7 +125,7 @@ describe('Transformer Registry - Transform All', () => {
       let WETH: IERC20;
       given(async () => {
         WETH = await ethers.getContractAt<IERC20>(IERC20_ABI, TOKENS['WETH'].address);
-        await registry.connect(signer).transformAllToDependent(WETH.address, RECIPIENT, { value: AMOUNT });
+        await registry.connect(signer).transformAllToDependent(WETH.address, RECIPIENT, AMOUNT, { value: AMOUNT });
       });
       then('all underlying tokens are transformed', async () => {
         const balance = await ethers.provider.getBalance(registry.address);

--- a/test/unit/transformers/erc-4626-transformer.spec.ts
+++ b/test/unit/transformers/erc-4626-transformer.spec.ts
@@ -140,13 +140,17 @@ describe('ERC4626Transformer', () => {
     when('function is called', () => {
       given(async () => {
         vault.redeem.returns(AMOUNT_UNDERLYING);
-        await transformer.transformToUnderlying(vault.address, AMOUNT_DEPENDENT, recipient.address);
+        await transformer.transformToUnderlying(vault.address, AMOUNT_DEPENDENT, recipient.address, [
+          { underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING },
+        ]);
       });
       then('vault is called correctly', () => {
         expect(vault.redeem).to.have.been.calledOnceWith(AMOUNT_DEPENDENT, recipient.address, signer.address);
       });
       then('underlying amount is returned correctly', async () => {
-        const underlying = await transformer.callStatic.transformToUnderlying(vault.address, AMOUNT_DEPENDENT, recipient.address);
+        const underlying = await transformer.callStatic.transformToUnderlying(vault.address, AMOUNT_DEPENDENT, recipient.address, [
+          { underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING },
+        ]);
         expect(underlying.length).to.equal(1);
         expect(underlying[0].amount).to.equal(AMOUNT_UNDERLYING);
         expect(underlying[0].underlying).to.equal(underlyingToken.address);
@@ -157,7 +161,7 @@ describe('ERC4626Transformer', () => {
   describe('transformToDependent', () => {
     invalidUnderlyingInputTest({
       func: 'transformToDependent',
-      input: (underlying) => [vault.address, underlying, recipient.address],
+      input: (underlying) => [vault.address, underlying, recipient.address, AMOUNT_DEPENDENT],
     });
     when('function is called', () => {
       given(async () => {
@@ -165,7 +169,8 @@ describe('ERC4626Transformer', () => {
         await transformer.transformToDependent(
           vault.address,
           [{ underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING }],
-          recipient.address
+          recipient.address,
+          AMOUNT_DEPENDENT
         );
       });
       then('underlying token is taken from caller', () => {
@@ -181,7 +186,8 @@ describe('ERC4626Transformer', () => {
         const amountDependent = await transformer.callStatic.transformToDependent(
           vault.address,
           [{ underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING }],
-          recipient.address
+          recipient.address,
+          AMOUNT_DEPENDENT
         );
         expect(amountDependent).to.equal(AMOUNT_DEPENDENT);
       });
@@ -191,7 +197,7 @@ describe('ERC4626Transformer', () => {
   describe('transformToExpectedUnderlying', () => {
     invalidUnderlyingInputTest({
       func: 'transformToExpectedUnderlying',
-      input: (underlying) => [vault.address, underlying, recipient.address],
+      input: (underlying) => [vault.address, underlying, recipient.address, AMOUNT_DEPENDENT],
     });
     when('function is called', () => {
       given(async () => {
@@ -199,7 +205,8 @@ describe('ERC4626Transformer', () => {
         await transformer.transformToExpectedUnderlying(
           vault.address,
           [{ underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING }],
-          recipient.address
+          recipient.address,
+          AMOUNT_DEPENDENT
         );
       });
       then('vault is called correctly', () => {
@@ -209,7 +216,8 @@ describe('ERC4626Transformer', () => {
         const spentDependent = await transformer.callStatic.transformToExpectedUnderlying(
           vault.address,
           [{ underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING }],
-          recipient.address
+          recipient.address,
+          AMOUNT_DEPENDENT
         );
         expect(spentDependent).to.equal(AMOUNT_DEPENDENT);
       });
@@ -221,7 +229,9 @@ describe('ERC4626Transformer', () => {
       given(async () => {
         vault.previewMint.returns(AMOUNT_UNDERLYING);
         vault.mint.returns(AMOUNT_UNDERLYING);
-        await transformer.transformToExpectedDependent(vault.address, AMOUNT_DEPENDENT, recipient.address);
+        await transformer.transformToExpectedDependent(vault.address, AMOUNT_DEPENDENT, recipient.address, [
+          { underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING },
+        ]);
       });
       then('preview mint is called correctly', () => {
         expect(vault.previewMint).to.have.been.calledOnceWith(AMOUNT_DEPENDENT);
@@ -239,7 +249,9 @@ describe('ERC4626Transformer', () => {
         expect(underlyingToken.transfer).to.not.have.been.called;
       });
       then('dependent amount is returned correctly', async () => {
-        const spentUnderlying = await transformer.callStatic.transformToExpectedDependent(vault.address, AMOUNT_DEPENDENT, recipient.address);
+        const spentUnderlying = await transformer.callStatic.transformToExpectedDependent(vault.address, AMOUNT_DEPENDENT, recipient.address, [
+          { underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING },
+        ]);
         expect(spentUnderlying.length).to.equal(1);
         expect(spentUnderlying[0].amount).to.equal(AMOUNT_UNDERLYING);
         expect(spentUnderlying[0].underlying).to.equal(underlyingToken.address);
@@ -249,7 +261,9 @@ describe('ERC4626Transformer', () => {
       given(async () => {
         vault.previewMint.returns(AMOUNT_UNDERLYING);
         vault.mint.returns(AMOUNT_UNDERLYING - 1);
-        await transformer.transformToExpectedDependent(vault.address, AMOUNT_DEPENDENT, recipient.address);
+        await transformer.transformToExpectedDependent(vault.address, AMOUNT_DEPENDENT, recipient.address, [
+          { underlying: underlyingToken.address, amount: AMOUNT_UNDERLYING },
+        ]);
       });
       then('preview mint is called correctly', () => {
         expect(vault.previewMint).to.have.been.calledOnceWith(AMOUNT_DEPENDENT);


### PR DESCRIPTION
We realized that we didn't have a way to set up a slippage configuration, so we were susceptive to sandwich attacks. The idea is that:
- We can configure a minOut amount for sell orders (`transformToUnderlying` and `transformToDependent`)
- We can configure a maxIn amount for buy orders (`transformToExpectedUnderlying` and `transformToExpectedDependent`)

This PR just:
1. Adds the new variables to the interfaces
2. Makes sure that the transformer registry is sending the new variables to the respective transformers

We are not checking the amounts yet, that will be done in another PR