### PR TITLE
feat: add deadline to transformers

### DIFF
--- a/solidity/contracts/TransformerRegistry.sol
+++ b/solidity/contracts/TransformerRegistry.sol
@@ -88,12 +88,13 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     uint256 _amountDependent,
     address _recipient,
-    UnderlyingAmount[] calldata _minAmountOut
+    UnderlyingAmount[] calldata _minAmountOut,
+    uint256 _deadline
   ) external payable returns (UnderlyingAmount[] memory) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient, _minAmountOut)
+      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient, _minAmountOut, _deadline)
     );
     return abi.decode(_result, (UnderlyingAmount[]));
   }
@@ -103,12 +104,13 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     UnderlyingAmount[] calldata _underlying,
     address _recipient,
-    uint256 _minAmountOut
+    uint256 _minAmountOut,
+    uint256 _deadline
   ) external payable returns (uint256 _amountDependent) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlying, _recipient, _minAmountOut)
+      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlying, _recipient, _minAmountOut, _deadline)
     );
     return abi.decode(_result, (uint256));
   }
@@ -117,13 +119,14 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   function transformAllToUnderlying(
     address _dependent,
     address _recipient,
-    UnderlyingAmount[] memory _minAmountOut
+    UnderlyingAmount[] memory _minAmountOut,
+    uint256 _deadline
   ) external payable returns (UnderlyingAmount[] memory) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     uint256 _amountDependent = IERC20(_dependent).balanceOf(msg.sender);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient, _minAmountOut)
+      abi.encodeWithSelector(_transformer.transformToUnderlying.selector, _dependent, _amountDependent, _recipient, _minAmountOut, _deadline)
     );
     return abi.decode(_result, (UnderlyingAmount[]));
   }
@@ -132,7 +135,8 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
   function transformAllToDependent(
     address _dependent,
     address _recipient,
-    uint256 _minAmountOut
+    uint256 _minAmountOut,
+    uint256 _deadline
   ) external payable returns (uint256) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
 
@@ -148,7 +152,7 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     // Delegate
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlyingAmount, _recipient, _minAmountOut)
+      abi.encodeWithSelector(_transformer.transformToDependent.selector, _dependent, _underlyingAmount, _recipient, _minAmountOut, _deadline)
     );
     return abi.decode(_result, (uint256));
   }
@@ -158,12 +162,20 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient,
-    uint256 _maxAmountIn
+    uint256 _maxAmountIn,
+    uint256 _deadline
   ) external payable returns (uint256 _spentDependent) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToExpectedUnderlying.selector, _dependent, _expectedUnderlying, _recipient, _maxAmountIn)
+      abi.encodeWithSelector(
+        _transformer.transformToExpectedUnderlying.selector,
+        _dependent,
+        _expectedUnderlying,
+        _recipient,
+        _maxAmountIn,
+        _deadline
+      )
     );
     return abi.decode(_result, (uint256));
   }
@@ -173,12 +185,20 @@ contract TransformerRegistry is BaseTransformer, ITransformerRegistry {
     address _dependent,
     uint256 _expectedDependent,
     address _recipient,
-    UnderlyingAmount[] calldata _maxAmountIn
+    UnderlyingAmount[] calldata _maxAmountIn,
+    uint256 _deadline
   ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {
     ITransformer _transformer = _getTransformerOrFail(_dependent);
     bytes memory _result = _delegateToTransformer(
       _transformer,
-      abi.encodeWithSelector(_transformer.transformToExpectedDependent.selector, _dependent, _expectedDependent, _recipient, _maxAmountIn)
+      abi.encodeWithSelector(
+        _transformer.transformToExpectedDependent.selector,
+        _dependent,
+        _expectedDependent,
+        _recipient,
+        _maxAmountIn,
+        _deadline
+      )
     );
     return abi.decode(_result, (UnderlyingAmount[]));
   }

--- a/solidity/contracts/transformers/BaseTransformer.sol
+++ b/solidity/contracts/transformers/BaseTransformer.sol
@@ -18,4 +18,9 @@ abstract contract BaseTransformer is CollectableDust, Multicall, ERC165, ITransf
       _interfaceId == type(IMulticall).interfaceId ||
       super.supportsInterface(_interfaceId);
   }
+
+  modifier checkDeadline(uint256 _deadline) {
+    if (block.timestamp > _deadline) revert TransactionExpired();
+    _;
+  }
 }

--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -61,8 +61,9 @@ contract ERC4626Transformer is BaseTransformer {
     address _dependent,
     uint256 _amountDependent,
     address _recipient,
-    UnderlyingAmount[] calldata _minAmountOut
-  ) external payable returns (UnderlyingAmount[] memory) {
+    UnderlyingAmount[] calldata _minAmountOut,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (UnderlyingAmount[] memory) {
     if (_minAmountOut.length != 1) revert InvalidUnderlyingInput();
     address _underlying = IERC4626(_dependent).asset();
     uint256 _amount = IERC4626(_dependent).redeem(_amountDependent, _recipient, msg.sender);
@@ -75,8 +76,9 @@ contract ERC4626Transformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _underlying,
     address _recipient,
-    uint256 _minAmountOut
-  ) external payable returns (uint256 _amountDependent) {
+    uint256 _minAmountOut,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (uint256 _amountDependent) {
     if (_underlying.length != 1) revert InvalidUnderlyingInput();
     IERC20 _underlyingToken = IERC20(_underlying[0].underlying);
     uint256 _underlyingAmount = _underlying[0].amount;
@@ -92,8 +94,9 @@ contract ERC4626Transformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient,
-    uint256 _maxAmountIn
-  ) external payable returns (uint256 _spentDependent) {
+    uint256 _maxAmountIn,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (uint256 _spentDependent) {
     if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _spentDependent = IERC4626(_dependent).withdraw(_expectedUnderlying[0].amount, _recipient, msg.sender);
     if (_maxAmountIn < _spentDependent) revert NeededMoreThanExpected(_spentDependent);
@@ -104,8 +107,9 @@ contract ERC4626Transformer is BaseTransformer {
     address _dependent,
     uint256 _expectedDependent,
     address _recipient,
-    UnderlyingAmount[] calldata _maxAmountIn
-  ) external payable returns (UnderlyingAmount[] memory) {
+    UnderlyingAmount[] calldata _maxAmountIn,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (UnderlyingAmount[] memory) {
     if (_maxAmountIn.length != 1) revert InvalidUnderlyingInput();
     // Check how much underlying would be needed to mint the vault tokens
     uint256 _neededUnderlying = IERC4626(_dependent).previewMint(_expectedDependent);

--- a/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
+++ b/solidity/contracts/transformers/ProtocolTokenWrapperTransformer.sol
@@ -55,8 +55,9 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _dependent,
     uint256 _amountDependent,
     address _recipient,
-    UnderlyingAmount[] calldata _minAmountOut
-  ) external payable returns (UnderlyingAmount[] memory) {
+    UnderlyingAmount[] calldata _minAmountOut,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (UnderlyingAmount[] memory) {
     if (_minAmountOut.length != 1) revert InvalidUnderlyingInput();
     // Since dependent & underlying are 1:1, we can preemptively check if received less than expected
     if (_minAmountOut[0].amount > _amountDependent) revert ReceivedLessThanExpected(_amountDependent);
@@ -69,8 +70,9 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _underlying,
     address _recipient,
-    uint256 _minAmountOut
-  ) external payable returns (uint256 _amountDependent) {
+    uint256 _minAmountOut,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (uint256 _amountDependent) {
     if (_underlying.length != 1) revert InvalidUnderlyingInput();
     _amountDependent = _underlying[0].amount;
     // Since dependent & underlying are 1:1, we can preemptively check if received less than expected
@@ -83,8 +85,9 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _dependent,
     UnderlyingAmount[] calldata _expectedUnderlying,
     address _recipient,
-    uint256 _maxAmountIn
-  ) external payable returns (uint256 _spentDependent) {
+    uint256 _maxAmountIn,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (uint256 _spentDependent) {
     if (_expectedUnderlying.length != 1) revert InvalidUnderlyingInput();
     _spentDependent = _expectedUnderlying[0].amount;
     // Since dependent & underlying are 1:1, we can preemptively check if needed more than expected
@@ -97,8 +100,9 @@ contract ProtocolTokenWrapperTransformer is BaseTransformer {
     address _dependent,
     uint256 _expectedDependent,
     address _recipient,
-    UnderlyingAmount[] calldata _maxAmountIn
-  ) external payable returns (UnderlyingAmount[] memory _spentUnderlying) {
+    UnderlyingAmount[] calldata _maxAmountIn,
+    uint256 _deadline
+  ) external payable checkDeadline(_deadline) returns (UnderlyingAmount[] memory _spentUnderlying) {
     if (_maxAmountIn.length != 1) revert InvalidUnderlyingInput();
     // Since dependent & underlying are 1:1, we can preemptively check if needed more than expected
     if (_maxAmountIn[0].amount < _expectedDependent) revert NeededMoreThanExpected(_expectedDependent);

--- a/solidity/interfaces/ITransformer.sol
+++ b/solidity/interfaces/ITransformer.sol
@@ -28,6 +28,9 @@ interface ITransformer {
   /// @notice Thrown when the transformation needs more input than expected
   error NeededMoreThanExpected(uint256 needed);
 
+  /// @notice Thrown when a transaction is executed after the deadline has passed
+  error TransactionExpired();
+
   /**
    * @notice Returns the addresses of all the underlying tokens, for the given dependent
    * @dev This function must be unaware of context. The returned values must be the same,
@@ -96,13 +99,15 @@ interface ITransformer {
    * @param minAmountOut The minimum amount of underlying that the caller expects to get. Will fail
    *                     if less is received. As a general rule, the underlying tokens should
    *                     be provided in the same order as `getUnderlying` returns them
+   * @param deadline A deadline when the transaction becomes invalid
    * @return The transformed amount in each of the underlying tokens
    */
   function transformToUnderlying(
     address dependent,
     uint256 amountDependent,
     address recipient,
-    UnderlyingAmount[] calldata minAmountOut
+    UnderlyingAmount[] calldata minAmountOut,
+    uint256 deadline
   ) external payable returns (UnderlyingAmount[] memory);
 
   /**
@@ -112,13 +117,15 @@ interface ITransformer {
    * @param recipient The address that would receive the dependent tokens
    * @param minAmountOut The minimum amount of dependent that the caller expects to get. Will fail
    *                     if less is received
+   * @param deadline A deadline when the transaction becomes invalid
    * @return amountDependent The transformed amount in the dependent token
    */
   function transformToDependent(
     address dependent,
     UnderlyingAmount[] calldata underlying,
     address recipient,
-    uint256 minAmountOut
+    uint256 minAmountOut,
+    uint256 deadline
   ) external payable returns (uint256 amountDependent);
 
   /**
@@ -128,13 +135,15 @@ interface ITransformer {
    * @param recipient The address that would receive the underlying tokens
    * @param maxAmountIn The maximum amount of dependent that the caller is willing to spend.
    *                    Will fail more is needed
+   * @param deadline A deadline when the transaction becomes invalid
    * @return spentDependent The amount of spent dependent tokens
    */
   function transformToExpectedUnderlying(
     address dependent,
     UnderlyingAmount[] calldata expectedUnderlying,
     address recipient,
-    uint256 maxAmountIn
+    uint256 maxAmountIn,
+    uint256 deadline
   ) external payable returns (uint256 spentDependent);
 
   /**
@@ -145,12 +154,14 @@ interface ITransformer {
    * @param maxAmountIn The maximum amount of underlying that the caller is willing to spend.
    *                    Will fail more is needed. As a general rule, the underlying tokens should
    *                    be provided in the same order as `getUnderlying` returns them
+   * @param deadline A deadline when the transaction becomes invalid
    * @return spentUnderlying The amount of spent underlying tokens
    */
   function transformToExpectedDependent(
     address dependent,
     uint256 expectedDependent,
     address recipient,
-    UnderlyingAmount[] calldata maxAmountIn
+    UnderlyingAmount[] calldata maxAmountIn,
+    uint256 deadline
   ) external payable returns (UnderlyingAmount[] memory spentUnderlying);
 }

--- a/solidity/interfaces/ITransformerRegistry.sol
+++ b/solidity/interfaces/ITransformerRegistry.sol
@@ -71,12 +71,14 @@ interface ITransformerRegistry is ITransformer {
    * @param minAmountOut The minimum amount of underlying that the caller expects to get. Will fail
    *                     if less is received. As a general rule, the underlying tokens should
    *                     be provided in the same order as `getUnderlying` returns them
+   * @param deadline A deadline when the transaction becomes invalid
    * @return The transformed amount in each of the underlying tokens
    */
   function transformAllToUnderlying(
     address dependent,
     address recipient,
-    UnderlyingAmount[] calldata minAmountOut
+    UnderlyingAmount[] calldata minAmountOut,
+    uint256 deadline
   ) external payable returns (UnderlyingAmount[] memory);
 
   /**
@@ -88,11 +90,13 @@ interface ITransformerRegistry is ITransformer {
    * @param recipient The address that would receive the dependent tokens
    * @param minAmountOut The minimum amount of dependent that the caller expects to get. Will fail
    *                     if less is received
+   * @param deadline A deadline when the transaction becomes invalid
    * @return amountDependent The transformed amount in the dependent token
    */
   function transformAllToDependent(
     address dependent,
     address recipient,
-    uint256 minAmountOut
+    uint256 minAmountOut,
+    uint256 deadline
   ) external payable returns (uint256 amountDependent);
 }

--- a/test/integration/registry-transform-all.spec.ts
+++ b/test/integration/registry-transform-all.spec.ts
@@ -83,7 +83,7 @@ describe('Transformer Registry - Transform All', () => {
       given(async () => {
         await dependent.connect(signer).approve(registry.address, INITIAL_DEPENDENT_BALANCE);
         expectedUnderlying = await registry.calculateTransformToUnderlying(dependent.address, INITIAL_DEPENDENT_BALANCE);
-        await registry.connect(signer).transformAllToUnderlying(dependent.address, RECIPIENT, expectedUnderlying);
+        await registry.connect(signer).transformAllToUnderlying(dependent.address, RECIPIENT, expectedUnderlying, constants.MaxUint256);
       });
       then('allowance is spent', async () => {
         expect(await dependent.allowance(signer.address, registry.address)).to.equal(0);
@@ -106,7 +106,7 @@ describe('Transformer Registry - Transform All', () => {
         expectedDependent = await registry.calculateTransformToDependent(dependent.address, [
           { underlying: underlying.address, amount: INITIAL_UNDERLYING_BALANCE },
         ]);
-        await registry.connect(signer).transformAllToDependent(dependent.address, RECIPIENT, expectedDependent);
+        await registry.connect(signer).transformAllToDependent(dependent.address, RECIPIENT, expectedDependent, constants.MaxUint256);
       });
       then('allowance is spent for all underlying tokens', async () => {
         expect(await underlying.allowance(signer.address, registry.address)).to.equal(0);
@@ -125,7 +125,7 @@ describe('Transformer Registry - Transform All', () => {
       let WETH: IERC20;
       given(async () => {
         WETH = await ethers.getContractAt<IERC20>(IERC20_ABI, TOKENS['WETH'].address);
-        await registry.connect(signer).transformAllToDependent(WETH.address, RECIPIENT, AMOUNT, { value: AMOUNT });
+        await registry.connect(signer).transformAllToDependent(WETH.address, RECIPIENT, AMOUNT, constants.MaxUint256, { value: AMOUNT });
       });
       then('all underlying tokens are transformed', async () => {
         const balance = await ethers.provider.getBalance(registry.address);


### PR DESCRIPTION
We are now adding a deadline to all transformations. This will allow the users to set an moment where they txs will expire, instead of having to cancel the tx manually