### PR TITLE
refactor: set approval to zero if unspent

### DIFF
--- a/solidity/contracts/transformers/ERC4626Transformer.sol
+++ b/solidity/contracts/transformers/ERC4626Transformer.sol
@@ -121,6 +121,7 @@ contract ERC4626Transformer is BaseTransformer {
       unchecked {
         _underlying.safeTransfer(msg.sender, _neededUnderlying - _spentUnderlying);
       }
+      _underlying.approve(_dependent, 0);
     }
     return _toSingletonArray(address(_underlying), _spentUnderlying);
   }

--- a/test/unit/transformers/erc-4626-transformer.spec.ts
+++ b/test/unit/transformers/erc-4626-transformer.spec.ts
@@ -328,8 +328,10 @@ describe('ERC4626Transformer', () => {
       then('underlying token is taken from caller', () => {
         expect(underlyingToken.transferFrom).to.have.been.calledOnceWith(signer.address, transformer.address, AMOUNT_UNDERLYING);
       });
-      then('underlying token is approved for vault', () => {
-        expect(underlyingToken.approve).to.have.been.calledOnceWith(vault.address, AMOUNT_UNDERLYING);
+      then('underlying token is approved for vault and then set to zero', () => {
+        expect(underlyingToken.approve).to.have.been.calledTwice;
+        expect(underlyingToken.approve).to.have.been.calledWith(vault.address, AMOUNT_UNDERLYING);
+        expect(underlyingToken.approve).to.have.been.calledWith(vault.address, 0);
       });
       then('mint is called correctly', () => {
         expect(vault.mint).to.have.been.calledOnceWith(AMOUNT_DEPENDENT, recipient.address);


### PR DESCRIPTION
With some tokens (like USDT), we can't call `approve` with a non-zero value if the allowance is also non-zero. In the case of calling `deposit`, the allowance will be fully spent. However, when we use `mint`, it might not be fully spent. So in that case, we will set the allowance back to zero, so that it can be used normally in the next call

_Note: I hate you USDT, so much_