### PR TITLE
test: wsteth integration test

### DIFF
--- a/deploy/004_wsteth_transformer.ts
+++ b/deploy/004_wsteth_transformer.ts
@@ -1,0 +1,39 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { bytecode } from '../artifacts/solidity/contracts/transformers/wstETHTransformer.sol/wstETHTransformer.json';
+import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
+import { DeployFunction } from '@0xged/hardhat-deploy/dist/types';
+
+const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployer, msig } = await hre.getNamedAccounts();
+
+  let stETH: string | undefined;
+  switch (hre.deployments.getNetworkName().toLowerCase()) {
+    case 'ethereum':
+      stETH = '0xae7ab96520de3a18e5e111b5eaab095312d7fe84';
+      break;
+  }
+
+  if (!stETH) return;
+
+  await deployThroughDeterministicFactory({
+    deployer,
+    name: 'wstETHTransformer',
+    salt: 'MF-wstETH-Transformer-V1',
+    contract: 'solidity/contracts/transformers/wstETHTransformer.sol:wstETHTransformer',
+    bytecode,
+    constructorArgs: {
+      types: ['address', 'address'],
+      values: [stETH, msig],
+    },
+    log: !process.env.TEST,
+    overrides: !!process.env.COVERAGE
+      ? {}
+      : {
+          gasLimit: 3_000_000,
+        },
+  });
+};
+
+deployFunction.dependencies = [];
+deployFunction.tags = ['wstETHTransformer'];
+export default deployFunction;

--- a/solidity/contracts/transformers/wstETHTransformer.sol
+++ b/solidity/contracts/transformers/wstETHTransformer.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-
 pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/interfaces/IERC20.sol';

--- a/test/integration/comprehensive-transformer-test.spec.ts
+++ b/test/integration/comprehensive-transformer-test.spec.ts
@@ -515,8 +515,10 @@ describe('Comprehensive Transformer Test', () => {
   }
 
   function expectToBeEqual(actual: BigNumberish, expected: BigNumberish, threshold?: BigNumberish) {
-    const thresholdBN = BigNumber.from(threshold ?? 0);
-    expect(actual).to.be.gte(BigNumber.from(expected).sub(thresholdBN)).and.lte(BigNumber.from(expected).add(thresholdBN));
+    const expectedBN = BigNumber.from(expected);
+    expect(actual)
+      .to.be.gte(expectedBN.sub(threshold ?? 0))
+      .and.lte(expectedBN.add(threshold ?? 0));
   }
 
   async function wrap(token: string): Promise<IERC20Like> {

--- a/test/integration/comprehensive-transformer-test.spec.ts
+++ b/test/integration/comprehensive-transformer-test.spec.ts
@@ -43,6 +43,14 @@ const TOKENS = {
   ETH: {
     address: PROTOCOL_TOKEN,
   },
+  stETH: {
+    address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
+    whale: '0x1982b2f5814301d4e9a8b0201555376e62f82428',
+  },
+  wstETH: {
+    address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+    whale: '0x10cd5fbe1b404b7e19ef964b63939907bdaf42e2',
+  },
 };
 
 describe('Comprehensive Transformer Test', () => {
@@ -75,12 +83,20 @@ describe('Comprehensive Transformer Test', () => {
         .registerTransformers([{ transformer: transformer.address, dependents: [TOKENS['WETH'].address] }]),
   });
 
+  transformerComprehensiveTest({
+    transformer: 'wstETHTransformer',
+    dependent: 'wstETH',
+    underlying: ['stETH'],
+    threshold: 2, // stETH can be lost on transfers, so we have a small 2-wei threshold
+  });
+
   function transformerComprehensiveTest({
     transformer: transformerName,
     title,
     dependent: dependentId,
     underlying: underlyingIds,
     transformerDependencies,
+    threshold,
     setup,
   }: {
     title?: string;
@@ -88,6 +104,7 @@ describe('Comprehensive Transformer Test', () => {
     dependent: keyof typeof TOKENS;
     underlying: (keyof typeof TOKENS)[];
     transformerDependencies?: string[];
+    threshold?: BigNumberish;
     setup?: (transformer: BaseTransformer, governor: JsonRpcSigner, dependencies: BaseTransformer[]) => Promise<any>;
   }) {
     contract(title ?? transformerName, () => {
@@ -171,8 +188,7 @@ describe('Comprehensive Transformer Test', () => {
             }
           });
           then('transforming back to dependent returns the same value', async () => {
-            // Note: this test assumes that there is no transform fee
-            expect(await transformer.calculateTransformToDependent(dependent.address, returnedUnderlying)).to.equal(AMOUNT_DEPENDENT);
+            expectToBeEqual(await transformer.calculateTransformToDependent(dependent.address, returnedUnderlying), AMOUNT_DEPENDENT, threshold);
           });
         });
       });
@@ -185,12 +201,11 @@ describe('Comprehensive Transformer Test', () => {
             returnedDependent = await transformer.calculateTransformToDependent(dependent.address, input);
           });
           then('transforming back to underlying returns the same value', async () => {
-            // Note: this test assumes that there is no transform fee
             const returnedUnderlying = await transformer.calculateTransformToUnderlying(dependent.address, returnedDependent);
             expect(returnedUnderlying.length).to.equal(underlying.length);
             for (const { underlying: underlyingToken, amount } of returnedUnderlying) {
               expect(isTokenUnderyling(underlyingToken)).to.be.true;
-              expect(amount).to.equal(AMOUNT_PER_UNDERLYING);
+              expectToBeEqual(amount, AMOUNT_PER_UNDERLYING, threshold);
             }
           });
         });
@@ -204,12 +219,11 @@ describe('Comprehensive Transformer Test', () => {
             neededDependent = await transformer.calculateNeededToTransformToUnderlying(dependent.address, input);
           });
           then('then transforming the result returns the expected underlying', async () => {
-            // Note: this test assumes that there is no transform fee
             const returnedUnderlying = await transformer.calculateTransformToUnderlying(dependent.address, neededDependent);
             expect(returnedUnderlying.length).to.equal(underlying.length);
             for (const { underlying: underlyingToken, amount } of returnedUnderlying) {
               expect(isTokenUnderyling(underlyingToken)).to.be.true;
-              expect(amount).to.equal(AMOUNT_PER_UNDERLYING);
+              expectToBeEqual(amount, AMOUNT_PER_UNDERLYING, threshold);
             }
           });
         });
@@ -228,8 +242,7 @@ describe('Comprehensive Transformer Test', () => {
             }
           });
           then('then transforming the result returns the expected underlying', async () => {
-            // Note: this test assumes that there is no transform fee
-            expect(await transformer.calculateTransformToDependent(dependent.address, neededUnderlying)).to.equal(AMOUNT_DEPENDENT);
+            expectToBeEqual(await transformer.calculateTransformToDependent(dependent.address, neededUnderlying), AMOUNT_DEPENDENT, threshold);
           });
         });
       });
@@ -259,7 +272,7 @@ describe('Comprehensive Transformer Test', () => {
             for (const { underlying, amount } of expectedUnderlying) {
               const token = await wrap(underlying);
               const recipientBalance = await token.balanceOf(RECIPIENT);
-              expect(recipientBalance).to.equal(amount);
+              expectToBeEqual(recipientBalance, amount, threshold);
             }
           });
         });
@@ -297,7 +310,7 @@ describe('Comprehensive Transformer Test', () => {
               if (underlyingToken.address === PROTOCOL_TOKEN) {
                 expect(balance).to.equal(INITIAL_SIGNER_BALANCE.sub(AMOUNT_PER_UNDERLYING).sub(gasSpent));
               } else {
-                expect(balance).to.equal(INITIAL_SIGNER_BALANCE.sub(AMOUNT_PER_UNDERLYING));
+                expectToBeEqual(balance, INITIAL_SIGNER_BALANCE.sub(AMOUNT_PER_UNDERLYING), threshold);
               }
             }
           });
@@ -333,7 +346,7 @@ describe('Comprehensive Transformer Test', () => {
           then('expected underlying tokens are sent to the recipient', async () => {
             for (const underlyingToken of underlying) {
               const recipientBalance = await underlyingToken.balanceOf(RECIPIENT);
-              expect(recipientBalance).to.equal(AMOUNT_PER_UNDERLYING);
+              expectToBeEqual(recipientBalance, AMOUNT_PER_UNDERLYING, threshold);
             }
           });
         });
@@ -427,12 +440,11 @@ describe('Comprehensive Transformer Test', () => {
             expect(returnedDependent1).to.equal(returnedDependent2);
           });
           then('transforming back to underlying returns the same value', async () => {
-            // Note: this test assumes that there is no transform fee
             const returnedUnderlying = await transformer.calculateTransformToUnderlying(dependent.address, returnedDependent1);
             expect(returnedUnderlying.length).to.equal(underlying.length);
             for (const { underlying: underlyingToken, amount } of returnedUnderlying) {
               expect(isTokenUnderyling(underlyingToken)).to.be.true;
-              expect(amount).to.equal(AMOUNT_PER_UNDERLYING);
+              expectToBeEqual(amount, AMOUNT_PER_UNDERLYING, threshold);
             }
           });
         });
@@ -500,6 +512,11 @@ describe('Comprehensive Transformer Test', () => {
         });
       }
     });
+  }
+
+  function expectToBeEqual(actual: BigNumberish, expected: BigNumberish, threshold?: BigNumberish) {
+    const thresholdBN = BigNumber.from(threshold ?? 0);
+    expect(actual).to.be.gte(BigNumber.from(expected).sub(thresholdBN)).and.lte(BigNumber.from(expected).add(thresholdBN));
   }
 
   async function wrap(token: string): Promise<IERC20Like> {


### PR DESCRIPTION
We are now adding an integration test for the wstETH transformer. When doing so, we realized that since stETH is a rebasing token, you can loose a few wei in each transfer.

We should be careful with this when integrating it into Mean